### PR TITLE
Declare Zev Kane site name via OG, application-name, and Person/WebSite schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,9 @@
     <meta name="description"
         content="Zev Kane is classical program director and host at Philadelphia's WRTI. Endlessly fascinated by classical music, he is also a musical curator and writer.">
     <link rel="canonical" href="https://zevkane.com/">
-    <meta property="og:type" content="profile">
+    <meta name="application-name" content="Zev Kane">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Zev Kane">
     <meta property="og:title" content="Zev Kane | Radio Host - Music Curator - Writer">
     <meta property="og:description" content="Zev Kane is classical program director and host at Philadelphia's WRTI. Endlessly fascinated by classical music, he is also a musical curator and writer.">
     <meta property="og:url" content="https://zevkane.com/">
@@ -45,6 +47,41 @@
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">
+    <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "WebSite",
+          "name": "Zev Kane",
+          "alternateName": "Zev Kane | Radio Host - Music Curator - Writer",
+          "url": "https://zevkane.com/"
+        }
+      </script>
+    <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "Person",
+          "name": "Zev Kane",
+          "url": "https://zevkane.com/",
+          "jobTitle": "Program Director",
+          "worksFor": {
+            "@type": "RadioStation",
+            "name": "WRTI",
+            "url": "https://www.wrti.org/"
+          },
+          "alumniOf": {
+            "@type": "CollegeOrUniversity",
+            "name": "Dartmouth College"
+          },
+          "sameAs": [
+            "https://open.spotify.com/show/60HOXjP6mEDfQtKtiuaXUH",
+            "https://twitter.com/zevkanemusic",
+            "https://www.linkedin.com/in/zeviel-kane-91252185/",
+            "https://open.spotify.com/user/12138479358",
+            "https://soundcloud.com/zev-kane",
+            "https://www.wrti.org/people/zeviel-kane"
+          ]
+        }
+      </script>
 </head>
 
 <body class="is-loading">


### PR DESCRIPTION
Add explicit site-name signals to zevkane.com so Google binds this domain to Zev's identity in search results, rather than inferring a weaker label from the `<title>` alone.

Changes, head-only, no visible DOM impact:

- Add `application-name` meta and `og:site_name` — both set to "Zev Kane".
- Change `og:type` from `profile` to `website`. Google's site-name feature specifically keys off `WebSite` schema declarations and `og:type=website`; `profile` is a valid OG value but not what the site-name signal expects.
- Append WebSite JSON-LD (`name`, `alternateName`, `url`) and Person JSON-LD (`jobTitle="Program Director"`, `worksFor=WRTI RadioStation`, `alumniOf=Dartmouth College`, `sameAs` linking the 6 non-email footer profiles: Spotify podcast, Twitter, LinkedIn, Spotify user, SoundCloud, WRTI bio page).
- No changes to `<title>`, `<h1>`, body markup, or existing Twitter / analytics / favicon metadata.

Follows the site-name reinforcement pattern from Google's site-name docs (https://developers.google.com/search/docs/appearance/site-names). JSON-LD validated via `json.loads`.